### PR TITLE
Automated Category detection in the query

### DIFF
--- a/run_ontology_closure.py
+++ b/run_ontology_closure.py
@@ -26,12 +26,10 @@ def run_end_to_end_test():
         "disease in ['diabetes mellitus'] and "
         "development_stage in ['10-month-old stage']"
     )
-    categories = ["cell_type", "tissue", "disease", "development_stage"]
     census_version = "latest"
 
     logger.info(f"Input Organism: {organism}")
     logger.info(f"Input Query Filter:\n{input_query_filter}")
-    logger.info(f"Categories to process: {categories}")
     logger.info(f"Census Version for filtering: {census_version}")
 
     # --- 2. Execute the obs_close function (the core of the pipeline) ---
@@ -40,7 +38,6 @@ def run_end_to_end_test():
     try:
         rewritten_filter = obs_close(
             input_query_filter,
-            categories,
             organism=organism,
             census_version=census_version,
         )

--- a/src/ontology_closure/onto_closure.py
+++ b/src/ontology_closure/onto_closure.py
@@ -381,9 +381,7 @@ class OntologyExtractor:
             logging.info(f"Saved hierarchy for {root_id} to {output_file}")
 
 
-def obs_close(
-    query_filter, categories=["cell_type"], organism=None, census_version=None
-):
+def obs_close(query_filter, categories=None, organism=None, census_version=None):
     """
     Rewrites the query filter to include ontology closure and filters IDs against the CellxGene Census.
 
@@ -396,6 +394,18 @@ def obs_close(
     Returns:
     - str: The rewritten query filter with expanded terms based on ontology closure.
     """
+
+    if categories is None:
+        matches = re.findall(r"(\w+?)(?:_ontology_term_id)?\s+in\s+\[", query_filter)
+        categories = list(set(matches))
+        logging.info(f"Auto-detected categories: {categories}")
+
+    # Add a check here if you want to ensure 'categories' is not empty
+    # or if you want to filter it against 'known_ontology_fields'
+    if not categories:
+        logging.info("No categories to process. Returning original filter.")
+        return query_filter
+
     if "development_stage" in categories and not organism:
         raise ValueError(
             "The 'organism' parameter is required for the 'development_stage' category."


### PR DESCRIPTION
- Previously the category was set to cell_type by defaults if user does not pass the category parameter
- Automated Category detection so users don't have to pass a "category" parameter when querying obs_closure